### PR TITLE
docs: capitalize Discord reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Detailed specifications for the OP Stack can be found within the [OP Stack Specs
 
 ## Community
 
-General discussion happens most frequently on the [Optimism discord](https://discord.gg/optimism).
+General discussion happens most frequently on the [Optimism Discord](https://discord.gg/optimism).
 Governance discussion can also be found on the [Optimism Governance Forum](https://gov.optimism.io/).
 
 ## Contributing


### PR DESCRIPTION
## Summary
- fix capitalization of Optimism Discord link in README

## Testing
- `make lint-go` *(fails: unsupported version of the configuration)*
- `just todo-checker` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6897cf378ecc8323aa2ffa0db45b3ee5